### PR TITLE
Fix: Set indefinite timeout for live audio recording

### DIFF
--- a/frontend/src/pages/Upload.tsx
+++ b/frontend/src/pages/Upload.tsx
@@ -1153,7 +1153,14 @@ function LiveMicPanel({
       if (sessionId) {
         console.log('[LIVE] stop(): calling /live/stop', { sessionId })
         const t0 = performance.now()
-        const res = await apiClient.post(`/api/v1/live/stop?session_id=${encodeURIComponent(sessionId)}`)
+        const res = await apiClient.post(
+          `/api/v1/live/stop?session_id=${encodeURIComponent(sessionId)}`,
+          undefined, // No request body
+          {
+            // Set indefinite timeout for this request
+            timeout: 0,
+          }
+        )
         const dt = Math.round(performance.now() - t0)
         const txt = (res.data?.final_text as string) || ''
         const cid = (res.data?.call_id as string) || null


### PR DESCRIPTION
The API call to stop a live recording was timing out after 30 seconds, causing an error for longer recordings.

This commit fixes the issue by setting the `timeout` option to `0` in the `axios` request for the `/api/v1/live/stop` endpoint. This effectively creates an indefinite timeout for this specific request, allowing the backend to process recordings of any length without the frontend timing out.