### PR TITLE
diag: log raw whisper output, per-pass dedup, concat duration to investigate word-loss

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -707,7 +707,8 @@ async def live_stop(session_id: str):
             try:
                 import time
                 t_start = time.time()
-                last_count = len(chunks)
+                start_count = len(chunks)
+                last_count = start_count
                 while time.time() - t_start < 1.5:
                     # Re-scan chunks list
                     cur = list(sess.chunks)
@@ -717,7 +718,10 @@ async def live_stop(session_id: str):
                         await asyncio.sleep(0.1)
                     else:
                         await asyncio.sleep(0.1)
-                logger.info(f"[MIC] stop quiesce complete session_id={session_id} chunks_count={len(chunks)}")
+                logger.info(
+                    "[STOP] grace session_id=%s chunks_at_grace_start=%d at_grace_end=%d added=%d",
+                    session_id, start_count, len(chunks), len(chunks) - start_count,
+                )
             except Exception:
                 pass
 
@@ -760,6 +764,26 @@ async def live_stop(session_id: str):
                     raise HTTPException(status_code=500, detail="audio_concat_failed")
                 combined_to_use = str(combined_path)
                 concat_ok = True
+                # Log ffmpeg stderr on success too — it reports dropped frames / discontinuities
+                # that we silently ignore otherwise.
+                if proc.stderr:
+                    logger.info("[CONCAT] ffmpeg stderr=%s", proc.stderr.strip())
+                # Compare transcoded WAV duration to expected (chunks * timeslice).
+                try:
+                    actual = float(audio_processor.analyze_audio_file(combined_to_use).get("duration_seconds") or 0)
+                    expected = float(len(chunks)) * 4.0
+                    delta = actual - expected
+                    logger.info(
+                        "[CONCAT] duration_check session_id=%s chunks=%d expected=%.2fs actual=%.2fs delta=%.2fs",
+                        session_id, len(chunks), expected, actual, delta,
+                    )
+                    if abs(delta) > 1.0:
+                        logger.warning(
+                            "[CONCAT] duration mismatch >1s session_id=%s expected=%.2fs actual=%.2fs",
+                            session_id, expected, actual,
+                        )
+                except Exception as _e:
+                    logger.info("[CONCAT] duration_check skipped: %s", _e)
             except HTTPException:
                 raise
             except Exception as e:

--- a/backend/app/whisper_processor.py
+++ b/backend/app/whisper_processor.py
@@ -336,6 +336,8 @@ def _dedup_log_pass(pass_name: str, before: str, after: str) -> None:
             len(before), len(after),
             _diff_snippet(before, after),
         )
+        logger.info("[DEDUP][%s] BEFORE=%r", pass_name, before)
+        logger.info("[DEDUP][%s] AFTER =%r", pass_name, after)
     else:
         logger.debug("[DEDUP][%s] no change", pass_name)
 
@@ -498,6 +500,7 @@ class WhisperProcessor:
                 "[WHISPER-RAW] complete in %.2fs: words=%d chars=%d text=%r",
                 duration, raw_word_count, len(raw_text), raw_text[:300]
             )
+            logger.info("[WHISPER-RAW-FULL] %r", raw_text)
             logger.debug(f"Transcription result: {result}")
             
             # Normalize response to match expected output structure


### PR DESCRIPTION
## Summary
- Adds 5 INFO-level diagnostic logs to pinpoint where words are silently dropped in live transcription
- No behavior change — diagnostic-only patch
- Goal: confirm root cause of the "many words chopped off" bug **before** any fix

## What's logged
| Log key | Where | What it tells us |
|---|---|---|
| `[WHISPER-RAW-FULL]` | `whisper_processor.py:500` | Untruncated whisper.cpp output before any Python dedup. Ground truth. |
| `[DEDUP][<pass>] BEFORE/AFTER` | `whisper_processor.py:333` | Full strings for every dedup pass that changes text (`sentence_dedup`, `partial_phrase`, `ngram_dedup`, `trailing_rep`). Pinpoints the culprit pass. |
| `[STOP] grace ... chunks_at_grace_start / at_grace_end` | `main.py:707` | Detects whether late-arriving chunks race the 1.5s grace window at stop. |
| `[CONCAT] ffmpeg stderr` (on success) | `main.py:766` | Was only logged on failure. Reports dropped frames / timestamp discontinuities. |
| `[CONCAT] duration_check` | `main.py:773` | Compares transcoded WAV duration to expected (`chunks * 4s`). Warns if delta > 1s. |

## Diagnostic decision tree
After reproducing the bug on this branch:
```
grep -E "WHISPER-RAW-FULL|DEDUP\[|CONCAT|STOP\] grace" <log>
```
- If `WHISPER-RAW-FULL` already lacks the missing words → bug is **upstream** (VAD / concat / whisper). Check `[CONCAT] duration_check` next.
- If `WHISPER-RAW-FULL` has them but the saved transcript doesn't → bug is **downstream** (dedup). The `[DEDUP][<pass>] BEFORE/AFTER` lines pinpoint the pass.
- If `[STOP] grace` shows `added>0` near grace expiry → tail chunks racing the 1.5s window.

## Background
The Phase-3 audit identified 5 plausible causes for the word-loss bug, ranked:
1. Multi-pass dedup (`whisper_processor.py:120-340`) — `remove_repeated_ngrams` advances `i += 5` on a hit, can drop legitimate words after a repetition
2. Whisper-server's own VAD (`--vad --vad-threshold 0.3`) clipping edge words
3. Python Silero VAD (`min_speech_ratio=0.1`) skipping whole chunks with long pauses
4. WebM byte-concat + ffmpeg repair silently dropping frames
5. Whisper `logprob_threshold=-0.5` rejecting quiet/mumbled segments

These logs distinguish #1 (downstream) from #2-#5 (upstream) without changing behavior.

## Test plan
- [ ] Pull the branch, run a live recording where you previously saw words chopped off
- [ ] `tail -f` the backend log; grep the keys above
- [ ] Confirm the decision tree points to a specific subsystem
- [ ] Open a follow-up PR with the targeted fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)